### PR TITLE
Integrate notification preferences

### DIFF
--- a/ckanext/datarequests/controllers/ui_controller.py
+++ b/ckanext/datarequests/controllers/ui_controller.py
@@ -47,9 +47,13 @@ if 'notify' in ckan_extensions:
 
 
 def notify(template, datarequest):
-    ckanext_notify.send_slack_notification(template, datarequest)
-    ckanext_notify.send_email_notification(template, datarequest)
-
+    if ckanext_notify.org_notification_preference == 'Email Only':
+        ckanext_notify.send_email_notification(template, datarequest)
+    elif ckanext_notify.org_notification_preference == 'Email Only':
+        ckanext_notify.send_slack_notification(template, datarequest)
+    else:
+        ckanext_notify.send_slack_notification(template, datarequest)
+        ckanext_notify.send_email_notification(template, datarequest)
 
 def notify_in_background(template, datarequest):
     notify_process = Process(target=notify, args=(template, datarequest,))


### PR DESCRIPTION
#### What does this PR do?
This PR informs the data requests extension of the organization's notification preference so that it can send notifications of operations on data requests to the appropriate channels
#### Description of Task to be completed?
The task is to ensure that the data requests extension knows what channels are to be notified if an operation is executed on a data request.
#### How should this be manually tested?
1. With ckanext-notify plugin enables, set the notification preference.
2. Create a data request (or perform any operation on a data-request)
3. You will receive a notification on your preferred notification channel.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A